### PR TITLE
Support for Windows Subsystem for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ interpreter.
 
 **Important**: Please note that this Jupyter kernel only works on
 Windows on its `windows-support` branch. Certain features, such
-as unicode output, cause problems in this case.
+as unicode output, cause problems in this case. Windows users may
+also use the Windows Subsystem for Linux (WSL). Note that only
+WSL1 has been tested.
 
 ![mikrokosmos2](https://user-images.githubusercontent.com/5337877/28381708-11a1608a-6cbc-11e7-80da-2292d4716cdb.png)
 

--- a/mikrokosmoskernel/mikrokosmoskernel.py
+++ b/mikrokosmoskernel/mikrokosmoskernel.py
@@ -6,6 +6,10 @@ from pexpect import popen_spawn
 import pexpect
 import re
 import os
+from platform import uname
+
+_IS_WSL = 'Microsoft' in uname().release
+
 
 class MikrokosmosKernel(Kernel):
     implementation = 'IMikrokosmos'
@@ -20,8 +24,8 @@ class MikrokosmosKernel(Kernel):
     }
     banner = "Mikrokosmos - A lambda calculus interpreter (kernel v0.1.8)"
 
-    # Initialization, Windows needs PopenSpawn.
-    if (os.name == 'nt'):
+    # Initialization, Windows (and Windows Subsystem for Linux) needs PopenSpawn
+    if os.name == 'nt' or _IS_WSL:
         mikro = pexpect.popen_spawn.PopenSpawn('mikrokosmos')
     else:
         mikro = pexpect.spawn('mikrokosmos')
@@ -34,7 +38,7 @@ class MikrokosmosKernel(Kernel):
                    allow_stdin=False):
 
         # Windows needs a newline
-        is_windows = (os.name == 'nt')
+        is_windows = os.name == 'nt' or _IS_WSL
         if is_windows:
             endofline = '\n'
         else:


### PR DESCRIPTION
I have imikrokosmos working with Windows Subsystem for Linux (WSL). I have not tested extensively but it seems to work. There are no Unicode issues.
Turns out WSL just needs to use PopenSpawn too.

Note: I am using WSL version 1.
I have not tried WSL version 2, which I believe is full hypervisor emulation (more like just running Linux in VirtualBox for example). I would imagine it would work on WSL2 the same as on any Linux. I don't know what uname release string WSL2 returns. If someone is trying to make this work on WSL2 I would suggest test if it works with is_windows forced to false, then figure out how to detect WSL2 as opposed to WSL1 and change the logic accordingly.

I have added a brief note to the readme, you are of course welcome to reword this however you prefer.